### PR TITLE
Update GitHub Actions workflow and Vite configuration for root base path and error pages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,7 +34,7 @@ jobs:
       # Set base URL for GitHub Pages
       - name: Set base URL
         run: |
-          echo "VITE_BASE_URL=/${GITHUB_REPOSITORY#*/}/" >> .env.production
+          echo "VITE_BASE_URL=/" >> .env.production
 
       - name: Build
         run: pnpm run build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   return {
-    // Use base from environment variable or default to '/' for local development
+    // Always use root base path '/' by default instead of a subdirectory
     base: env.VITE_BASE_URL || '/',
     plugins: [
       vue(),
@@ -53,6 +53,14 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         input: {
           main: fileURLToPath(new URL('./index.html', import.meta.url)),
+          maintenance: fileURLToPath(new URL('./index.html', import.meta.url)),
+          // Add error pages to rollupOptions input
+          ...Object.fromEntries(
+            errorPages.map(errorCode => [
+              errorCode,
+              fileURLToPath(new URL('./index.html', import.meta.url)),
+            ]),
+          ),
         },
       },
     },


### PR DESCRIPTION
Configure the GitHub Actions workflow to set the base URL to the root path and modify the Vite configuration to always use the root base path. Additionally, include error pages in the Rollup options for better error handling.